### PR TITLE
Fix little bug in POST /games

### DIFF
--- a/app/src/Services/GamesService.php
+++ b/app/src/Services/GamesService.php
@@ -70,26 +70,26 @@ class GamesService
 
         if (!$validator->validate()) {
             $errors = $validator->errors();
-        }
+        } else {
+            // Validating FKs
+            if (!$this->developer_model->isValidDevId($game['Developer_Id'])) {
+                $errors['Developer_Id'][] = "Could not find developer with id [{$game['Developer_Id']}]";
+            };
 
-        // Validating FKs
-        if (!$this->developer_model->isValidDevId($game['Developer_Id'])) {
-            $errors['Developer_Id'][] = "Could not find developer with id [{$game['Developer_Id']}]";
-        };
+            if (!$this->genre_model->isValidGenreName($game['Genre_Name'])) {
+                $errors['Genre_Name'][] = "Could not find genre titled: [{$game['Genre_Name']}]";
+            }
 
-        if (!$this->genre_model->isValidGenreName($game['Genre_Name'])) {
-            $errors['Genre_Name'][] = "Could not find genre titled: [{$game['Genre_Name']}]";
-        }
+            if (!$this->country_model->isValidCountry($game['Country_Name'])) {
+                $errors['Country_Name'][] = "Could not find country named [{$game['Country_Name']}]";
+            }
 
-        if (!$this->country_model->isValidCountry($game['Country_Name'])) {
-            $errors['Country_Name'][] = "Could not find country named [{$game['Country_Name']}]";
-        }
-
-        // Validate ESRB
-        $game['ESRB'] = strtoupper($game['ESRB']);
-        if (!in_array($game['ESRB'], $this->valid_esrb_ratings)) {
-            $esrb_join = implode(", ", $this->valid_esrb_ratings);
-            $errors['ESRB'][] = "Invalid ESRB rating. Accepted ratings: {$esrb_join}";
+            // Validate ESRB
+            $game['ESRB'] = strtoupper($game['ESRB']);
+            if (!in_array($game['ESRB'], $this->valid_esrb_ratings)) {
+                $esrb_join = implode(", ", $this->valid_esrb_ratings);
+                $errors['ESRB'][] = "Invalid ESRB rating. Accepted ratings: {$esrb_join}";
+            }
         }
 
         // Return fail if any errors


### PR DESCRIPTION
When checking for valid FKs, it was giving an error if the field wasn't included in the body.
e.g. I could try to access $game['country_name'] when it wasn't guaranteed that it's set. Works now 👍🏼